### PR TITLE
add macro to print valiable easy-to-see

### DIFF
--- a/000/A.cpp
+++ b/000/A.cpp
@@ -8,6 +8,13 @@ using namespace std;
 #define REPL(i,m,n) for(ll i=(ll)(m); i<(ll)(n); i++)
 #define repl(i,n) REPL(i,0,n)
 #define all(v) v.begin(), v.end()
+#define check(val) cout << "\033[31m" << #val << ": " << val << "\033[m" << endl
+#define check_v(vec) \
+  do {                                    \
+    cout << "\033[31m" << #vec << ": [ "; \
+    for(auto e; v){cout << e << " ";}     \
+    cout << "]"<< "\033[m" << endl; }     \
+  while (0)
 // template<class t, class u>
 // ostream& operator<<(ostream& os, const pair<t, u>& p) {
 //   return os << "{" << p.first << ", " << p.second << "}";
@@ -37,4 +44,3 @@ const ll mod = 1e9+7;
 int main() {
   return 0;
 }
-

--- a/000/A.cpp
+++ b/000/A.cpp
@@ -8,13 +8,13 @@ using namespace std;
 #define REPL(i,m,n) for(ll i=(ll)(m); i<(ll)(n); i++)
 #define repl(i,n) REPL(i,0,n)
 #define all(v) v.begin(), v.end()
-#define check(val) cout << "\033[31m" << #val << ": " << val << "\033[m" << endl
+#define check(val) cout << "\033[31m" << #val << ": " << val << "\033[m" << endl;
 #define check_v(vec) \
   do {                                    \
     cout << "\033[31m" << #vec << ": [ "; \
-    for(auto e; v){cout << e << " ";}     \
-    cout << "]"<< "\033[m" << endl; }     \
-  while (0)
+    for(auto e: vec) {cout << e << " "; }   \
+    cout << "]" << "\033[m" << endl; }     \
+  while (0);
 // template<class t, class u>
 // ostream& operator<<(ostream& os, const pair<t, u>& p) {
 //   return os << "{" << p.first << ", " << p.second << "}";


### PR DESCRIPTION
整数型の変数やコンテナ型の変数の中身を簡単に見やすく表示するマクロを追加しました。

複数文に渡るマクロはdo-whileで囲わないと文字列を置換した時に予期せぬエラーを起こす可能性があるらしいので、少し長いですがdo-whileで囲っておきました。
https://www.jpcert.or.jp/sc-rules/c-pre10-c.html

今の状態では、表示可能/不可能な型は以下のとおりです。
表示可能
- int
- vector
- string
- deque
- array
- 固定長配列

表示不可能
- map
- set

mapに関しては、<<演算子をpair型用にオーバーロードしたら表示できるようになります。
setに関しては、check_vの中のfor文を(auto it=vec.begin(); it!=vec.end(); it++)としたら表示できるようになりますが、そうすると固定長配列が表示できなくなるので難しいところです。